### PR TITLE
Fix load order preventing Gem from being 'require'd.

### DIFF
--- a/lib/itglue/asset.rb
+++ b/lib/itglue/asset.rb
@@ -1,4 +1,9 @@
-Dir[File.join(File.dirname(__FILE__), 'asset/*.rb')].each {|file| require file }
+require File.join(File.dirname(__FILE__), 'asset/base.rb')
+require File.join(File.dirname(__FILE__), 'asset/configuration.rb')
+require File.join(File.dirname(__FILE__), 'asset/configuration_interface.rb')
+require File.join(File.dirname(__FILE__), 'asset/configuration_status.rb')
+require File.join(File.dirname(__FILE__), 'asset/configuration_type.rb')
+require File.join(File.dirname(__FILE__), 'asset/organization.rb')
 
 module ITGlue
   module Asset


### PR DESCRIPTION
Hello. I couldn't `require 'itglue'` as I'd get:

```
/home/bb/code/github/itglue/lib/itglue/asset/configuration_interface.rb:2:in `<module:ITGlue>': uninitialized constant ITGlue::Asset (NameError)
```

I changed the dir/file loading order and it works for me now.

Not sure if this is a version thing. I'm running Arch Linux, and

`ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]`